### PR TITLE
Add proof of concept for saving/restoring app-db

### DIFF
--- a/src/day8/re_frame/trace/components/container.cljs
+++ b/src/day8/re_frame/trace/components/container.cljs
@@ -5,6 +5,7 @@
             [day8.re-frame.trace.panels.subvis :as subvis]
             [day8.re-frame.trace.panels.traces :as traces]
             [day8.re-frame.trace.panels.subs :as subs]
+            [day8.re-frame.trace.panels.save :as save]
             [re-frame.trace]
             [reagent.core :as r]))
 
@@ -29,7 +30,8 @@
        (tab-button :traces "Traces")
        (tab-button :app-db "App DB")
        (tab-button :subs "Subs")
-       #_ (tab-button :subvis "SubVis")
+       (tab-button :save "Save")
+       #_(tab-button :subvis "SubVis")
        (when-not external-window?
          [:img.popout-icon
           {:src      (str "data:image/svg+xml;utf8,"
@@ -40,4 +42,5 @@
        :app-db [app-db/render-state db/app-db]
        :subvis [subvis/render-subvis traces]
        :subs [subs/subs-panel]
+       :save [save/save-panel]
        [app-db/render-state db/app-db])]))

--- a/src/day8/re_frame/trace/panels/save.cljs
+++ b/src/day8/re_frame/trace/panels/save.cljs
@@ -1,0 +1,30 @@
+(ns day8.re-frame.trace.panels.save
+  (:require [mranderson047.re-frame.v0v10v2.re-frame.core :as rf]
+            [re-frame.db]
+            [day8.re-frame.trace.utils.localstorage :as localstorage]))
+
+(rf/reg-event-db
+  :save/save-app-db
+  (fn [db _]
+    (localstorage/save! "saved-app-db" @re-frame.db/app-db)
+    db
+    ))
+
+(rf/reg-event-db
+  :save/restore-app-db
+  (fn [db _]
+    (if-let [app-db (localstorage/get "saved-app-db")]
+      (reset! re-frame.db/app-db app-db)
+      db)))
+
+(defn save-panel []
+  [:div
+   [:h1 "Save State"]
+   [:br]
+   [:button.text-button
+    {:on-click #(rf/dispatch [:save/save-app-db])}
+    "Save"]
+   [:br]
+   [:button.text-button
+    {:on-click #(rf/dispatch [:save/restore-app-db])}
+    "Reload"]])


### PR DESCRIPTION
This is not to be merged, but opening for discussion. It would be useful to be able to save a snapshot of app-state to be able to restore from later on, either within the same browser session or in a later one.

Current goals:
* Serialise state and reload it within the same browser session
* Serialise state and reload it against the same version of the application, but in a different session.

Out of scope:
* Saving state from remote users and loading it into a debugging build
* Exporting state
* This working on different versions of code.

I found two issues immediately with the serialisation approach I have taken:

* Some objects in app-db are not deserialisable, e.g. deftypes that haven't got a custom printer/reader.
* In the todomvc example, there is a spec for the maps being ordered maps. However an ordered map serialised with `prn` is indistinguishable from a standard map and will cause a spec exception.

Both of these show that ser/de is likely to be the big blocker for this being a useful feature. I'm interested in hearing about other options here which can handle a wider range of datatypes than EDN.

One possibility is to use Transit and allow [users to extend our transit readers and writers](http://blog.cognitect.com/blog/2015/9/10/extending-transit). I would probably prefer something more automatic but less compatible, like storing the memory representation and then reading it back. This is likely to be challenging for a variety of reasons though.

Another likely issue is being able to do some sort of pre and post initialisation, e.g. to synchronise localstorage, get new auth tokens, e.t.c.