### PR TITLE
Add re-frame.subs, re-frame.fx, and re-frame.cofx to :require

### DIFF
--- a/src/day8/re_frame_10x/view/parts.cljs
+++ b/src/day8/re_frame_10x/view/parts.cljs
@@ -1,7 +1,10 @@
 (ns day8.re-frame-10x.view.parts
   (:require [day8.re-frame-10x.utils.re-com :as rc]
             [re-frame.registrar]
-            [re-frame.events]))
+            [re-frame.events]
+            [re-frame.subs]
+            [re-frame.fx]
+            [re-frame.cofx]))
 
 (defn render-registered [kind]
   (for [[k v] (sort-by key (get @re-frame.registrar/kind->id->handler kind))]


### PR DESCRIPTION
`day8.re-frame-10x.view.parts` does not require `re-frame.subs`, `re-frame.fx`, and `re-frame.cofx`, all of which it uses. This causes shadow-cljs to throw warnings on initial compile: 

```
11:41:42 CLJS | ------ WARNING #1 --------------------------------------------------------------
11:41:42 CLJS |  File: day8/re_frame_10x/view/parts.cljs:26:28
11:41:42 CLJS | --------------------------------------------------------------------------------
11:41:42 CLJS |   23 |    :children [[:h1 "Events"]
11:41:42 CLJS |   24 |               (render-registered re-frame.events/kind)
11:41:42 CLJS |   25 |               [:h1 "Subscriptions"]
11:41:42 CLJS |   26 |               (render-subs re-frame.subs/kind)
11:41:42 CLJS | ----------------------------------^---------------------------------------------
11:41:42 CLJS |  Use of undeclared Var re-frame.subs/kind
11:41:42 CLJS | --------------------------------------------------------------------------------
11:41:42 CLJS |   27 |               [:h1 "FX"]
11:41:42 CLJS |   28 |               (render-registered re-frame.fx/kind)
11:41:42 CLJS |   29 |               [:h1 "co-fx"]
11:41:42 CLJS |   30 |               (render-registered re-frame.cofx/kind)
11:41:42 CLJS | --------------------------------------------------------------------------------
11:41:42 CLJS | 
11:41:42 CLJS | ------ WARNING #2 --------------------------------------------------------------
11:41:42 CLJS |  File: day8/re_frame_10x/view/parts.cljs:28:34
11:41:42 CLJS | --------------------------------------------------------------------------------
11:41:42 CLJS |   25 |               [:h1 "Subscriptions"]
11:41:42 CLJS |   26 |               (render-subs re-frame.subs/kind)
11:41:42 CLJS |   27 |               [:h1 "FX"]
11:41:42 CLJS |   28 |               (render-registered re-frame.fx/kind)
11:41:42 CLJS | ----------------------------------------^---------------------------------------
11:41:42 CLJS |  Use of undeclared Var re-frame.fx/kind
11:41:42 CLJS | --------------------------------------------------------------------------------
11:41:42 CLJS |   29 |               [:h1 "co-fx"]
11:41:42 CLJS |   30 |               (render-registered re-frame.cofx/kind)
11:41:42 CLJS |   31 |               ]])
11:41:42 CLJS | --------------------------------------------------------------------------------
11:41:42 CLJS | 
11:41:42 CLJS | ------ WARNING #3 --------------------------------------------------------------
11:41:42 CLJS |  File: day8/re_frame_10x/view/parts.cljs:30:34
11:41:42 CLJS | --------------------------------------------------------------------------------
11:41:42 CLJS |   27 |               [:h1 "FX"]
11:41:42 CLJS |   28 |               (render-registered re-frame.fx/kind)
11:41:42 CLJS |   29 |               [:h1 "co-fx"]
11:41:42 CLJS |   30 |               (render-registered re-frame.cofx/kind)
11:41:42 CLJS | ----------------------------------------^---------------------------------------
11:41:42 CLJS |  Use of undeclared Var re-frame.cofx/kind
11:41:42 CLJS | --------------------------------------------------------------------------------
11:41:42 CLJS |   31 |               ]])
11:41:42 CLJS | --------------------------------------------------------------------------------
```

Requiring these namespaces will fix this issue.