### PR TITLE
Fix undeclared var warnings

### DIFF
--- a/src/day8/re_frame_10x/view/components.cljs
+++ b/src/day8/re_frame_10x/view/components.cljs
@@ -6,6 +6,7 @@
             [day8.re-frame-10x.utils.re-com :as rc]
             [mranderson047.reagent.v0v7v0.reagent.core :as r]
             [devtools.prefs]
+            [devtools.formatters.core]
             [cljsjs.react-highlight]
             [cljsjs.highlight.langs.clojure])
   (:require-macros [day8.re-frame-10x.utils.macros :refer [with-cljs-devtools-prefs]]))
@@ -236,4 +237,3 @@
    :child [:span {:style {:margin "auto"}} label]])
 
 (def highlight (r/adapt-react-class js/Highlight))
-


### PR DESCRIPTION
I'm seeing these warnings when using this project:

```
WARNING: Use of undeclared Var devtools.formatters.core/header-api-call at line 112 resources/js/app.out/day8/re_frame_10x/view/components.cljs
WARNING: Use of undeclared Var devtools.formatters.core/body-api-call at line 115 resources/js/app.out/day8/re_frame_10x/view/components.cljs
WARNING: Use of undeclared Var devtools.formatters.core/has-body-api-call at line 118 resources/js/app.out/day8/re_frame_10x/view/components.cljs
```

This PR resolves those warnings.