### PR TITLE
Store scroll position in component atom, rather than in app-db

### DIFF
--- a/src/day8/re_frame_10x/events.cljs
+++ b/src/day8/re_frame_10x/events.cljs
@@ -689,10 +689,10 @@
             match-array-index (utils/find-index-in-vec (fn [x] (= current-id x)) match-ids)
             new-id            (nth match-ids (inc match-array-index))]
         {:db         (assoc db :current-epoch-id new-id)
-         :dispatch-n [[:code/clear-scroll-pos] [:snapshot/reset-current-epoch-app-db new-id]]})
+         :dispatch   [:snapshot/reset-current-epoch-app-db new-id]})
       (let [new-id (utils/last-in-vec (:match-ids db))]
         {:db         (assoc db :current-epoch-id new-id)
-         :dispatch-n [[:code/clear-scroll-pos] [:snapshot/reset-current-epoch-app-db new-id]]}))))
+         :dispatch   [:snapshot/reset-current-epoch-app-db new-id]}))))
 
 (rf/reg-event-db
   :epochs/most-recent-epoch
@@ -777,18 +777,6 @@
     (if (= form new-form)
       nil
       new-form)))
-
-(rf/reg-event-db
-  :code/save-scroll-pos
-  [(rf/path [:code :scroll-pos])]
-  (fn [_scroll-pos [_ top left]]
-    {:top top :left left}))
-
-(rf/reg-event-db
-  :code/clear-scroll-pos
-  [(rf/path [:code :scroll-pos])]
-  (fn [_scroll-pos _]
-    {:top 0 :left 0}))
 
 ;;
 

--- a/src/day8/re_frame_10x/subs.cljs
+++ b/src/day8/re_frame_10x/subs.cljs
@@ -648,13 +648,6 @@
   (fn [code _]
     (:highlighted-form code)))
 
-(rf/reg-sub
-  :code/scroll-pos
-  :<- [:code/root]
-  (fn [code _]
-    (:scroll-pos code)))
-
-
 ;;
 
 (rf/reg-sub

--- a/src/day8/re_frame_10x/view/event.cljs
+++ b/src/day8/re_frame_10x/view/event.cljs
@@ -115,9 +115,14 @@
 
 (defn event-expression
   []
-  (let [scroll-pos (rf/subscribe [:code/scroll-pos])]
+  (let [scroll-pos (atom {:top 0 :left 0})]
     (reagent/create-class
-      {:component-did-update
+      {:component-will-update
+       (fn event-expression-component-will-update [this]
+         (let [node (reagent/dom-node this)]
+           (reset! scroll-pos {:top (.-scrollTop node) :left (.-scrollLeft node)})))
+
+       :component-did-update
        (fn event-expression-component-did-update [this]
          (let [node (reagent/dom-node this)]
            (set! (.-scrollTop node) (:top @scroll-pos))
@@ -144,7 +149,6 @@
                     :overflow         "auto"
                     :border           "1px solid #e3e9ed"
                     :background-color common/white-background-color}
-            :attr {:on-scroll (handler-fn (rf/dispatch [:code/save-scroll-pos (-> event .-target .-scrollTop) (-> event .-target .-scrollLeft)]))}
             :child (if (some? highlighted-form)
                      [components/highlight {:language "clojure"}
                       (list ^{:key "before"} before


### PR DESCRIPTION
This avoids app-db churn and has the benefit of removing code and making this component more generic when we come to use it in other places.