### PR TITLE
Require clojure.data

### DIFF
--- a/src/day8/re_frame_10x/view/subs.cljs
+++ b/src/day8/re_frame_10x/view/subs.cljs
@@ -8,7 +8,8 @@
             [day8.re-frame-10x.utils.re-com :as rc :refer [css-join]]
             [day8.re-frame-10x.common-styles :as common]
             [day8.re-frame-10x.view.components :as components]
-            [mranderson048.garden.v1v3v3.garden.units :as units])
+            [mranderson048.garden.v1v3v3.garden.units :as units]
+            [clojure.data])
   (:require-macros [day8.re-frame-10x.utils.macros :as macros]
                    [day8.re-frame-10x.utils.re-com :refer [handler-fn]]))
 


### PR DESCRIPTION
If compiling via shadow-cljs, an exception is thrown when the diff box is ticked. Requiring `clojure.data` fixes.

Relates to #173 