### PR TITLE
Use KeyboardEvent.code instead of KeyboardEvent.key to toggle inspection

### DIFF
--- a/src/day8/re_frame_10x.cljs
+++ b/src/day8/re_frame_10x.cljs
@@ -170,11 +170,11 @@
         handle-keys          (fn [e]
                                (let [combo-key?      (or (.-ctrlKey e) (.-metaKey e) (.-altKey e))
                                      tag-name        (.-tagName (.-target e))
-                                     key             (.-key e)
+                                     code            (.-code e)
                                      entering-input? (contains? #{"INPUT" "SELECT" "TEXTAREA"} tag-name)]
                                  (when (and (not entering-input?) combo-key?)
                                    (cond
-                                     (and (= key "h") (.-ctrlKey e))
+                                     (and (= code "KeyH") (.-ctrlKey e))
                                      (do (rf/dispatch [:settings/user-toggle-panel])
                                          (.preventDefault e))))))
         handle-mousemove     (fn [e]


### PR DESCRIPTION
Fixes #207 
### Description
`Ctrl-h` shortcut does not work if non-english layout is active.
This happens because [KeyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) is used  [here](https://github.com/Day8/re-frame-10x/blob/master/src/day8/re_frame_10x.cljs#L173) to detect `Ctrl-h`. `KeyboardEvent.key` returns layout-specific character and though differ accross layouts.

The fix is to use [KeyboardEvent.code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) instead, which is stable accross different layouts and always returns `KeyH` for `h` key.

### How this was tested
1. Create test project with re-frame-10x using leiningen re-frame template
2. Setup test project as described [here](https://github.com/Day8/re-frame-10x/blob/master/DEVELOPERS.md)
3. Tested manually in 
- Chrome 66.0.3359.181
- Firefox 59.0.2
- Safari 11.1 (13605.1.33.1.4)