### PR TITLE
Enable programmatically opening or closing panel

### DIFF
--- a/src/day8/re_frame_10x.cljs
+++ b/src/day8/re_frame_10x.cljs
@@ -243,3 +243,6 @@
 
 (defn ^:export factory-reset! []
   (rf/dispatch [:settings/factory-reset]))
+
+(defn ^:export show-panel! [show-panel?]
+  (rf/dispatch [:settings/show-panel? show-panel?]))


### PR DESCRIPTION
To hide the panel, run `(day8.re-frame-10x/show-panel! false)` from ClojureScript, or `day8.re_frame_10x.trace.show_panel_BANG_(false)` in the JavaScript console. To show the panel, pass `true` instead.

This would satisfy #181. It might also help some use cases in #204.

I prefer dispatching `:settings/show-panel?` over `:settings/user-toggle-panel` because it's idempotent. You have to first check the current state of the panel to know what will happen with `:settings/user-toggle-panel`. Let me know, though, if you'd prefer to keep `:settings/show-panel?` internal.