### PR TITLE
Fixes Firefox rendering issue

### DIFF
--- a/src/day8/re_frame_10x/common_styles.cljs
+++ b/src/day8/re_frame_10x/common_styles.cljs
@@ -205,7 +205,8 @@
 
    ;; Default text color overrides
    [:body {:color default-text-color}]
-   [:.form-control {:color default-text-color}]
+   [:.form-control {:color default-text-color
+                    :width "100%"}]
    [:.btn-default {:color default-text-color}]
    [:.raptor-editable-block {:color default-text-color}]
 


### PR DESCRIPTION
For some reason, Firefox has a hard cutoff of any text being rendered beyond 205px width. This small patch fixes this.