### PR TITLE
Version bump in the README to 0.3.6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ It helps you find false assumptions faster.
 
 Branch | React Version | Status | Artifact
 ----------|--------|--------|--------
-`master` | React 15 | [![CircleCI](https://circleci.com/gh/Day8/re-frame-10x.svg?style=svg)](https://circleci.com/gh/Day8/re-frame-10x) | `[day8.re-frame/re-frame-10x "0.3.4"]`
-`react-16` | React 16 | [![CircleCI](https://circleci.com/gh/Day8/re-frame-10x/tree/react-16.svg?style=svg)](https://circleci.com/gh/Day8/re-frame-10x/tree/react-16) | `[day8.re-frame/re-frame-10x "0.3.4-react16"]`
+`master` | React 15 | [![CircleCI](https://circleci.com/gh/Day8/re-frame-10x.svg?style=svg)](https://circleci.com/gh/Day8/re-frame-10x) | `[day8.re-frame/re-frame-10x "0.3.6"]`
+`react-16` | React 16 | [![CircleCI](https://circleci.com/gh/Day8/re-frame-10x/tree/react-16.svg?style=svg)](https://circleci.com/gh/Day8/re-frame-10x/tree/react-16) | `[day8.re-frame/re-frame-10x "0.3.6-react16"]`
 
 ## Show Me
 [Conduit demo with re-frame-10x](https://jacekschae.github.io/conduit-re-frame-10x-demo/)


### PR DESCRIPTION
`0.3.4`, the current version listed in the README, fails with the following error:
```
----  Could not Analyze  resources/public/js/compiled/out/day8/re_frame_10x/subs.cljs  ----

  No such namespace: mranderson048.re-frame.v0v10v2.re-frame.core, could not locate mranderson048/re_frame/v0v10v2/re_frame/core.cljs, mranderson048/re_frame/v0v10v2/re_frame/core.cljc, or JavaScript source providing "mranderson048.re-frame.v0v10v2.re-frame.core" (Please check that namespaces with dashes use underscores in the ClojureScript file name)
```
If you use `0.3.6` this error no longer appears.