### PR TITLE
Uncaught TypeError: Cannot read property 'document' of null

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ re-frame-10x includes an experimental code tracing feature for tracing the code 
 * Reset the settings to factory defaults in the settings panel
 * If you can't load the settings panel, run `day8.re_frame_10x.trace.factory_reset_BANG_()` in the JavaScript console.
 * If neither of those work, remove all of the keys with the prefix `day8.re-frame.trace` from your browser's Local Storage.
+* If pop-ups are blocked by your browser (Chrome), it can cause confusing exception `Uncaught TypeError: Cannot read property 'document' of null` followed by stack trace mentioning `mranderson`. The solution is to always allow pop-ups from your app under development URL (e.g. http://0.0.0.0:3449).
 
 ### Some parts of re-frame-10x seem to work but others don't
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,6 @@ re-frame-10x includes an experimental code tracing feature for tracing the code 
 * Reset the settings to factory defaults in the settings panel
 * If you can't load the settings panel, run `day8.re_frame_10x.trace.factory_reset_BANG_()` in the JavaScript console.
 * If neither of those work, remove all of the keys with the prefix `day8.re-frame.trace` from your browser's Local Storage.
-* If pop-ups are blocked by your browser (Chrome), it can cause confusing exception `Uncaught TypeError: Cannot read property 'document' of null` followed by stack trace mentioning `mranderson`. The solution is to always allow pop-ups from your app under development URL (e.g. http://0.0.0.0:3449).
 
 ### Some parts of re-frame-10x seem to work but others don't
 

--- a/src/day8/re_frame_10x/events.cljs
+++ b/src/day8/re_frame_10x/events.cljs
@@ -282,15 +282,16 @@
         ;; control over this, it will only position it within the same display that it was popped out on.
         w                (js/window.open "about:blank" "re-frame-10x-popout"
                                          (str "width=" width ",height=" height ",left=" left ",top=" top
-                                              ",resizable=yes,scrollbars=yes,status=no,directories=no,toolbar=no,menubar=no"))
-
-        d                (.-document w)]
-    (when-let [el (.getElementById d "--re-frame-10x--")]
-      (r/unmount-component-at-node el))
-    (.open d)
-    (.write d new-window-html)
-    (goog.object/set w "onload" #(mount w d))
-    (.close d)))
+                                              ",resizable=yes,scrollbars=yes,status=no,directories=no,toolbar=no,menubar=no"))]
+    (if-not w
+      (js/console.error "CANNOT OPEN re-frame-10x DEBUGGER WINDOW! Allow pop-ups from this URL.")
+      (let [d (.-document w)]
+        (when-let [el (.getElementById d "--re-frame-10x--")]
+          (r/unmount-component-at-node el))
+        (.open d)
+        (.write d new-window-html)
+        (goog.object/set w "onload" #(mount w d))
+        (.close d)))))
 
 (rf/reg-event-fx
   :global/launch-external


### PR DESCRIPTION
If pop-ups are blocked by your browser (Chrome), it can cause confusing exception `Uncaught TypeError: Cannot read property 'document' of null` followed by stack trace mentioning `mranderson`. The solution is to always allow pop-ups from your app under development URL (e.g. http://0.0.0.0:3449).

This probably occurs only when the browser was closed previously with separate re-frame-10x debugging window. I have spent a long time to figure out, so I think it should be mentioned in README.md to be easily searchable.

Thanks!