### PR TITLE
Event/epoch history explorer

### DIFF
--- a/src/day8/re_frame_10x/common_styles.cljs
+++ b/src/day8/re_frame_10x/common_styles.cljs
@@ -141,6 +141,12 @@
 (def wizard-step-current-color "#C7FF66")                   ;; Bright lime green
 (def wizard-step-future-color dark-background-color)
 
+(def history-background-color "#32323C")                    ;; Dark black
+(def history-item-background-color "#636A6F")               ;; Very dark grey
+(def history-item-text-color "white")
+(def history-item-hover-color "#6EC0E6")                    ;; Our standard rich blue colour
+(def history-item-active-color "#767A7C")                   ;; Medium grey
+
 (def font-stack ["\"Segoe UI\"" "Roboto", "Helvetica", "sans-serif"])
 
 ;; =================================================================================================

--- a/src/day8/re_frame_10x/common_styles.cljs
+++ b/src/day8/re_frame_10x/common_styles.cljs
@@ -145,7 +145,8 @@
 (def history-item-background-color "#636A6F")               ;; Very dark grey
 (def history-item-text-color "white")
 (def history-item-hover-color "#6EC0E6")                    ;; Our standard rich blue colour
-(def history-item-active-color "#767A7C")                   ;; Medium grey
+(def history-item-active-color "#E66E96")                   ;; Magenta
+(def history-item-inactive-color "#767A7C")                 ;; Medium grey
 
 (def font-stack ["\"Segoe UI\"" "Roboto", "Helvetica", "sans-serif"])
 

--- a/src/day8/re_frame_10x/events.cljs
+++ b/src/day8/re_frame_10x/events.cljs
@@ -713,6 +713,13 @@
                    :current-epoch-id nil)
      :dispatch [:snapshot/reset-current-epoch-app-db (utils/last-in-vec (:match-ids db))]}))
 
+(rf/reg-event-fx
+  :epochs/load-epoch
+  [(rf/path [:epochs])]
+  (fn [{:keys [db]} [_ new-id]]
+    {:db       (assoc db :current-epoch-id new-id)
+     :dispatch [:snapshot/reset-current-epoch-app-db new-id]}))
+
 (rf/reg-event-db
   :epochs/replay
   [(rf/path [:epochs])]
@@ -831,3 +838,10 @@
   [(rf/path [:errors])]
   (fn [errors _]
     (dissoc errors :popup-failed?)))
+
+;;
+
+(rf/reg-event-db
+  :history/toggle-history
+  (fn [db _]
+    (update-in db [:history :showing-history?] not)))

--- a/src/day8/re_frame_10x/styles.cljs
+++ b/src/day8/re_frame_10x/styles.cljs
@@ -11,7 +11,8 @@
             [day8.re-frame-10x.view.settings :as settings]
             [day8.re-frame-10x.view.event :as event]
             [day8.re-frame-10x.view.fx :as fx]
-            [day8.re-frame-10x.view.container :as container]))
+            [day8.re-frame-10x.view.container :as container]
+            [day8.re-frame-10x.view.history :as history]))
 
 (def background-gray common/background-gray)
 (def background-gray-hint common/background-gray-hint)
@@ -522,6 +523,7 @@
                      container/container-styles
                      event/event-styles
                      fx/fx-styles
+                     history/history-styles
                      app-db/app-db-styles
                      timing/timing-styles
                      settings/settings-styles]))

--- a/src/day8/re_frame_10x/styles.cljs
+++ b/src/day8/re_frame_10x/styles.cljs
@@ -375,13 +375,17 @@
                             :cursor "auto"}]
     [:span.arrow.epoch-nav {:min-width "16px"
                             :max-width "16px"}]
+    [:span.arrow.epoch-aux-nav {:min-width   "12px"
+                                :max-width   "12px"
+                                :height      "9px"
+                                :line-height "9px"}]
     [:span.event-header {:color            common/default-text-color
                          :background-color common/standard-background-color
                          :padding          (px 5)
                          :font-weight      "600"
                          ;; TODO: figure out how to hide long events
-                         :text-overflow    "ellipsis"}]
-    ]
+                         :text-overflow    "ellipsis"}]]
+
    [(s/& :.external-window) {:display "flex"
                              :height  (percent 100)
                              :flex    "1 1 auto"}]

--- a/src/day8/re_frame_10x/subs.cljs
+++ b/src/day8/re_frame_10x/subs.cljs
@@ -251,6 +251,18 @@
     (:epochs db)))
 
 (rf/reg-sub
+  :epochs/all-indexed-events
+  :<- [:epochs/epoch-root]
+  (fn [epochs _]
+    (mapv (fn [match]
+            (-> match
+                :match-info
+                metam/matched-event
+                ((juxt #(get-in % [:id])
+                       #(get-in % [:tags :event])))))
+          (:matches epochs))))
+
+(rf/reg-sub
   :epochs/current-match-state
   :<- [:epochs/epoch-root]
   :<- [:epochs/match-ids]
@@ -756,3 +768,10 @@
   :<- [:errors/root]
   (fn [errors _]
     (:popup-failed? errors)))
+
+;;
+
+(rf/reg-sub
+  :history/showing-history?
+  (fn [db _]
+    (get-in db [:history :showing-history?])))

--- a/src/day8/re_frame_10x/subs.cljs
+++ b/src/day8/re_frame_10x/subs.cljs
@@ -258,7 +258,7 @@
             (-> match
                 :match-info
                 metam/matched-event
-                ((juxt #(get-in % [:id])
+                ((juxt #(or (get % :child-of) (get % :id))
                        #(get-in % [:tags :event])))))
           (:matches epochs))))
 

--- a/src/day8/re_frame_10x/subs.cljs
+++ b/src/day8/re_frame_10x/subs.cljs
@@ -251,16 +251,12 @@
     (:epochs db)))
 
 (rf/reg-sub
-  :epochs/all-indexed-events
+  :epochs/all-events-by-id
   :<- [:epochs/epoch-root]
   (fn [epochs _]
-    (mapv (fn [match]
-            (-> match
-                :match-info
-                metam/matched-event
-                ((juxt #(or (get % :child-of) (get % :id))
-                       #(get-in % [:tags :event])))))
-          (:matches epochs))))
+    (->> (map (juxt key (comp :event :tags metam/matched-event :match-info val))
+              (:matches-by-id epochs))
+         (sort-by first >))))
 
 (rf/reg-sub
   :epochs/current-match-state

--- a/src/day8/re_frame_10x/view/container.cljs
+++ b/src/day8/re_frame_10x/view/container.cljs
@@ -148,7 +148,7 @@
                  [rc/v-box
                   :gap common/gs-5s
                   :children
-                  [[:span.arrow.epoch-nav
+                  [[:span.arrow.epoch-aux-nav
                     (if newer-epochs-available?
                       {:on-click #(do (rf/dispatch [:component/set-direction :next])
                                       (rf/dispatch [:epochs/most-recent-epoch]))
@@ -160,10 +160,9 @@
                       :style    {:cursor        (if newer-epochs-available? "pointer" "default")
                                  :height        "10px"
                                  :margin-bottom "-1px"}}]]
-                   [:span.arrow.epoch-nav
+                   [:span.arrow.epoch-aux-nav
                     {:on-click #(rf/dispatch [:history/toggle-history])
-                     :title    "Show event history"
-                     :style    {:height "10px"}}
+                     :title    "Show event history"}
                     (if showing-history?
                       "▲"
                       "▼")]]]]]

--- a/src/day8/re_frame_10x/view/history.cljs
+++ b/src/day8/re_frame_10x/view/history.cljs
@@ -17,21 +17,30 @@
       :margin           "2px"
       :padding          "5px"
       :font-weight      "600"
-      :text-overflow    "ellipsis"}
+      :text-overflow    "ellipsis"
+      :cursor           "pointer"}
      [:&:hover
       {:color common/history-item-hover-color}]]
     [:.history-item.active
-     {:color common/history-item-active-color}]]])
+     {:color  common/history-item-active-color
+      :cursor "default"}]
+    [:.history-item.inactive
+     {:color common/history-item-inactive-color}
+     [:&:hover
+      {:color common/history-item-hover-color}]]]])
 
-(defn history-item [id event active?]
-  (let [event-str (pp/truncate 400 :end event)]
+(defn history-item [id event match-id current-id]
+  (let [event-str (pp/truncate 400 :end event)
+        active? (= match-id current-id)
+        inactive? (> match-id current-id)]
     [:span
      (merge
-       {:class    (str "history-item" (when active? " active"))}
+       {:class    (str "history-item"
+                       (when active? " active")
+                       (when inactive? " inactive"))}
        (when-not active?
-         {:on-click #(rf/dispatch [:epochs/load-epoch (dec id)])
-          :title    "Jump to this epoch"
-          :style    {:cursor "pointer"}}))
+         {:on-click #(rf/dispatch [:epochs/load-epoch match-id])
+          :title    "Jump to this epoch"}))
      event-str]))
 
 (defn render []
@@ -42,5 +51,5 @@
      :height "20%"
      :children [(for [[id event] (rseq all-events)]
                   ^{:key id}
-                  [history-item id event (= (dec id) current-id)])]]))
+                  [history-item id event (dec id) current-id])]]))
 

--- a/src/day8/re_frame_10x/view/history.cljs
+++ b/src/day8/re_frame_10x/view/history.cljs
@@ -17,8 +17,11 @@
       :margin           "2px"
       :padding          "5px"
       :font-weight      "600"
+      :cursor           "pointer"
       :text-overflow    "ellipsis"
-      :cursor           "pointer"}
+      :white-space      "nowrap"
+      :overflow         "hidden"
+      :flex-shrink      0}
      [:&:hover
       {:color common/history-item-hover-color}]]
     [:.history-item.active

--- a/src/day8/re_frame_10x/view/history.cljs
+++ b/src/day8/re_frame_10x/view/history.cljs
@@ -47,12 +47,12 @@
      event-str]))
 
 (defn render []
-  (let [all-events @(rf/subscribe [:epochs/all-indexed-events])
+  (let [all-events @(rf/subscribe [:epochs/all-events-by-id])
         current-id @(rf/subscribe [:epochs/current-epoch-id])]
     [rc/v-box
      :class "history-list"
      :height "20%"
-     :children [(for [[id event] (rseq all-events)]
+     :children [(for [[id event] all-events]
                   ^{:key id}
                   [history-item event id current-id])]]))
 

--- a/src/day8/re_frame_10x/view/history.cljs
+++ b/src/day8/re_frame_10x/view/history.cljs
@@ -52,7 +52,8 @@
     [rc/v-box
      :class "history-list"
      :height "20%"
-     :children [(for [[id event] all-events]
-                  ^{:key id}
-                  [history-item event id current-id])]]))
+     :children [(for [[id event] all-events
+                      :when (not-empty event)]
+                     ^{:key id}
+                     [history-item event id current-id])]]))
 

--- a/src/day8/re_frame_10x/view/history.cljs
+++ b/src/day8/re_frame_10x/view/history.cljs
@@ -32,17 +32,17 @@
      [:&:hover
       {:color common/history-item-hover-color}]]]])
 
-(defn history-item [id event match-id current-id]
+(defn history-item [event id current-id]
   (let [event-str (pp/truncate 400 :end event)
-        active? (= match-id current-id)
-        inactive? (> match-id current-id)]
+        active?   (= id current-id)
+        inactive? (> id current-id)]
     [:span
      (merge
-       {:class    (str "history-item"
-                       (when active? " active")
-                       (when inactive? " inactive"))}
+       {:class (str "history-item"
+                    (when active?   " active")
+                    (when inactive? " inactive"))}
        (when-not active?
-         {:on-click #(rf/dispatch [:epochs/load-epoch match-id])
+         {:on-click #(rf/dispatch [:epochs/load-epoch id])
           :title    "Jump to this epoch"}))
      event-str]))
 
@@ -54,5 +54,5 @@
      :height "20%"
      :children [(for [[id event] (rseq all-events)]
                   ^{:key id}
-                  [history-item id event (dec id) current-id])]]))
+                  [history-item event id current-id])]]))
 

--- a/src/day8/re_frame_10x/view/history.cljs
+++ b/src/day8/re_frame_10x/view/history.cljs
@@ -1,0 +1,46 @@
+(ns day8.re-frame-10x.view.history
+  (:require [day8.re-frame-10x.utils.re-com :as rc]
+            [day8.re-frame-10x.inlined-deps.re-frame.v0v10v6.re-frame.core :as rf]
+            [day8.re-frame-10x.common-styles :as common]
+            [day8.re-frame-10x.utils.pretty-print-condensed :as pp]))
+
+(def history-styles
+  [:#--re-frame-10x--
+   [:.history-list
+    {:background-color common/history-background-color
+     :overflow-y       "scroll"
+     :overflow-x       "hidden"
+     :resize           "vertical"}
+    [:.history-item
+     {:color            common/history-item-text-color
+      :background-color common/history-item-background-color
+      :margin           "2px"
+      :padding          "5px"
+      :font-weight      "600"
+      :text-overflow    "ellipsis"}
+     [:&:hover
+      {:color common/history-item-hover-color}]]
+    [:.history-item.active
+     {:color common/history-item-active-color}]]])
+
+(defn history-item [id event active?]
+  (let [event-str (pp/truncate 400 :end event)]
+    [:span
+     (merge
+       {:class    (str "history-item" (when active? " active"))}
+       (when-not active?
+         {:on-click #(rf/dispatch [:epochs/load-epoch (dec id)])
+          :title    "Jump to this epoch"
+          :style    {:cursor "pointer"}}))
+     event-str]))
+
+(defn render []
+  (let [all-events @(rf/subscribe [:epochs/all-indexed-events])
+        current-id @(rf/subscribe [:epochs/current-epoch-id])]
+    [rc/v-box
+     :class "history-list"
+     :height "20%"
+     :children [(for [[id event] (rseq all-events)]
+                  ^{:key id}
+                  [history-item id event (= (dec id) current-id)])]]))
+


### PR DESCRIPTION
Thanks for the immensely useful dev tool!

I think we can make it even better! Something I miss from a similar tool (Redux dev tools) is an overview/history of all events/epochs, allowing you to scroll through them and jump to a specific one.

I created a MVP that fulfills the above description, but I'd like to get some feedback on it and some ideas I have to improve it, which I'll work on next week.

![2019-07-12-175557_670x338_scrot](https://user-images.githubusercontent.com/3865590/61145034-c8c7ba80-a4d6-11e9-8c7e-b72fcb6bd1ca.png)

It's hidden by default and is toggled with the up/down arrow below the skip-to-last button (which I made smaller and pushed up).

Here's the stuff on my list:
- [x] Fix alignment and sizes of *skip-to-last* and *toggle* button
- [ ] Save open/close state to local storage so it can be restored (not sure if this is worth doing as I imagine the *history explorer* would generally be used to jump between a few epochs, then close it once done)
- [x] Fix first event *init-db* not being shown as active when selected (differing id?)
- [x] Perhaps different font color for future events when any other than the most recent event is selected, to indicate that these haven't happened yet
- [x] ~~Try to make the simple *css resize* handle prettier~~ *not possible in firefox, and it looks fine in chrome/webkit*
- [x] If possible, simplify the `:epochs/all-indexed-events` sub (name could be improved as well?)
- [x] Test with long events to make sure they create ellipses

Update: I'm pretty happy with how things are now, so I'll wait for feedback for now.