### PR TITLE
Prevent nil component path from trace map

### DIFF
--- a/src/day8/re_frame_10x.cljs
+++ b/src/day8/re_frame_10x.cljs
@@ -51,7 +51,9 @@
    (fn mp-render []                                         ;; Monkeypatched render
      (this-as c
        (trace/with-trace {:op-type   :render
-                          :tags      {:component-path (component-path c)}
+                          :tags      (if-let [path (component-path c)]
+                                       {:component-path path}
+                                       {})
                           :operation (operation-name c)}
                          (if util/*non-reactive*
                            (reagent.impl.component/do-render c)


### PR DESCRIPTION
The computation of component path allows for nil and the part that uses it checks for the absence of a value but not the presence of nil in the map.

```clj
(defn log-trace? [trace]
  (let [render-operation? (or (= (:op-type trace) :render)
                              (= (:op-type trace) :componentWillUnmount))
        component-path    (get-in trace [:tags :component-path] "")] ;; doesn't guard against nil in the map
    (if-not render-operation?
      true
      (not (str/includes? component-path "devtools outer")))))
```