### PR TITLE
fix shadow-cljs warning for using newer react deps

### DIFF
--- a/src/deps.cljs
+++ b/src/deps.cljs
@@ -1,4 +1,4 @@
-{:npm-deps {"react"              "16.9.0"
-            "react-dom"          "16.9.0"
+{:npm-deps {"react"              "^16.9.0"
+            "react-dom"          "^16.9.0"
             "highlight.js"       "9.15.10"
             "react-highlight.js" "1.0.7"}}


### PR DESCRIPTION
i'm using shadow-cljs and react 16.12.0.
after upgrading to v0.5.1 i get the following warnings during build:
```
NPM dependency "react" has installed version "16.12.0"
"16.9.0" was required by jar:file:/home/user/.m2/repository/day8/re-frame/re-frame-10x/0.5.1/re-frame-10x-0.5.1.jar!/deps.cljs
NPM dependency "react-dom" has installed version "16.12.0"
"16.9.0" was required by jar:file:/home/user/.m2/repository/day8/re-frame/re-frame-10x/0.5.1/re-frame-10x-0.5.1.jar!/deps.cljs
```
this PR removes these warnings for newer 16.x versions of react.