### PR TITLE
Changed to overflow auto to hide scrolling bar automatically

### DIFF
--- a/src/day8/re_frame_10x/view/app_db.cljs
+++ b/src/day8/re_frame_10x/view/app_db.cljs
@@ -306,7 +306,7 @@
   [rc/v-box
    :size "1"
    :style {:margin-right common/gs-19s
-           :overflow "scroll"}
+           :overflow "auto"}
            ;:overflow     "hidden"
 
    :children [[panel-header]


### PR DESCRIPTION
Thanks for merging #259 ! 
I've just noticed that by adding the overflow css there I added a scrolling bar even when there is no overflow, sorry about that. So I've just changed this one line to avoid it: now the scroll bar will appear only when scrolling is needed