### PR TITLE
Update DEVELOPERS.md to use shadow-cljs alias

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -7,7 +7,7 @@ application, but in many cases is all you need to work on re-frame-10x.
 
 ```console
 $ cd examples/todomvc
-$ lein do clean, figwheel
+$ lein do clean, dev-auto
 ```
 
 ### Setting up re-frame-10x for development (more advanced)


### PR DESCRIPTION
The old figwheel command no longer works as the project.clj for the todomvc example has been migrated to shadow-cljs.