### PR TITLE
Fix trace--toggle selector in rule.

### DIFF
--- a/src/day8/re_frame_10x/styles.cljs
+++ b/src/day8/re_frame_10x/styles.cljs
@@ -264,9 +264,8 @@
        {:border-bottom  [[(px 1) "dotted" light-purple]]
         :padding-bottom 0}]]]
 
-    ["&:hover"
-     {".trace--toggle"
-      {:color text-color}}]
+    ["&:hover.trace--toggle"
+      {:color text-color}]
     ["th" "td"
      ["&:first-child" {:padding-left "7px"}]
      ["&:last-child" {:padding-right "7px"}]]]


### PR DESCRIPTION
The previously generated CSS gives:
#--re-frame-10x-- tr:hover { .trace--toggle-color: #767A7C;}

The second selector ended up concatenated with the rule using the old nesting.