### PR TITLE
Adds proper use of vendor prefix for match-parent.

### DIFF
--- a/src/day8/re_frame_10x/styles.cljs
+++ b/src/day8/re_frame_10x/styles.cljs
@@ -124,8 +124,10 @@
      :box-sizing         "border-box"
      :margin-top         "3px"}]
 
-   [:li {:display    "list-item"
-         :text-align "-webkit-match-parent"}]
+   [:li {:display "list-item"}]
+   [:li
+    ^{:prefix true :vendors [:webkit]}
+    {:text-align "match-parent" }]
 
    [:table :thead :tbody :tfoot :tr :th :td
     {:display                           "block"


### PR DESCRIPTION
This will generate CSS with prefixed and non-prefixed match-parent rules for list-items' alignment. This is supported in most modern browsers, only Safari requires a vendor prefix.