### PR TITLE
Improves documentation for shadow-cljs setup

### DIFF
--- a/docs/Advanced-Setup.md
+++ b/docs/Advanced-Setup.md
@@ -34,5 +34,20 @@ re-frame-10x is designed for development time debugging. The overhead that it im
 There may be more hurdles to cross after this one, Here Be Dragons, if you figure it out, let us know!
 
 ## Using Shadow CLJS?
+On `shadow-cljs.edn` add the following:
+```clj
+{:dependencies [;; your other dependencies
+                [day8.re-frame/tracing "0.6.2"]
+                [binaryage/devtools "1.0.2"]
+                [day8.re-frame/re-frame-10x "1.0.2"]]
 
-Dependencies will be automatically installed via shadow-cljs's `deps.cljs` transitive dependency mechanism.     
+ :builds {:app {:modules {:app {:preloads [devtools.preload day8.re-frame-10x.preload]}}
+                :dev {:compiler-options {:closure-defines {re-frame.trace.trace-enabled? true
+                                                           day8.re-frame.tracing.trace-enabled? true}}}
+                :release {:build-options
+                          {:ns-aliases
+                           {day8.re-frame.tracing day8.re-frame.tracing-stubs}}}}}}
+```
+
+
+Otherwise, if using `deps.cljs` manage your dependencies, then they will be automatically installed via shadow-cljs's `deps.cljs` transitive dependency mechanism.     


### PR DESCRIPTION
I was very confused by the current documentation regarding the setup with `shadow-cljs`. After some time I found the [re-frame-template](https://github.com/day8/re-frame-template) repository which cleared things up quite a bit.

This PR is based on the resulting `shadow-cljs.edn` produced by this command: `lein new re-frame shadow-reframe +10x`.

I am quite new to `re-frame` so I am not sure if `re-frame/tracing` is a required dependency for this to work. I am also not sure what the following means, but I guess it's useful:

```clj
:release {:build-options
                 {:ns-aliases
                    {day8.re-frame.tracing day8.re-frame.tracing-stubs}}}
```

I hope this will help others like me to figure out an easy way to setup this dependency when using `shadow-cljs`.
