### PR TITLE
Update devtools to 1.0.4

### DIFF
--- a/examples/todomvc/shadow-cljs.edn
+++ b/examples/todomvc/shadow-cljs.edn
@@ -7,7 +7,7 @@
   [zprint                               "1.0.1"]
   [superstructor/re-highlight           "1.1.0"]
   [secretary                            "1.2.3"]
-  [binaryage/devtools                   "1.0.3"]
+  [binaryage/devtools                   "1.0.4"]
   [metosin/malli                        "0.5.1"]]
 
  :source-paths ["src" "../../src" "../../gen-src"]

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
 
   :dependencies [[org.clojure/clojure                  "1.10.3"   :scope "provided"]
                  [org.clojure/clojurescript            "1.10.879" :scope "provided"]
-                 [binaryage/devtools                   "1.0.3"]
+                 [binaryage/devtools                   "1.0.4"]
                  [com.yahoo.platform.yui/yuicompressor "2.4.8"
                   :exclusions [rhino/js]]
                  [zprint                               "1.0.1"]


### PR DESCRIPTION
Devtools released version `1.0.4` that includes the new feature to add paths to json-ml. 
Merging this currently might transfer the issues #329 #330 and #331 to more users. Currently those issues should only show to users who have included devtools version `1.0.4` in their project.clj files.