### PR TITLE
Override indenting in maps

### DIFF
--- a/src/day8/re_frame_10x/styles.cljs
+++ b/src/day8/re_frame_10x/styles.cljs
@@ -335,7 +335,10 @@
    {:outline [[(px 1) :dotted :ButtonText]]}]
 
   [:textarea
-   {:overflow :auto}])
+   {:overflow :auto}]
+
+  [:ol
+   {:padding-inline-start 0}])
 
 ;; nord0 nord6 background when not syntax
 ;; nord1 nord4 background prominent/focused


### PR DESCRIPTION
Fixes #309 by overriding the `padding` applied to `ol` by the user agent stylesheet