### PR TITLE
Add button to expand or collapse entire app-db

### DIFF
--- a/src/day8/re_frame_10x/components/cljs_devtools.cljs
+++ b/src/day8/re_frame_10x/components/cljs_devtools.cljs
@@ -295,17 +295,18 @@
            (conj path :header)))])))
 
 (defn data-structure-with-path-annotations [_ indexed-path devtools-path {:keys [update-path-fn object] :as opts}]
-  (let [expanded? (rf/subscribe [::app-db.subs/node-expanded? indexed-path])]
+  (let [expanded?   (rf/subscribe [::app-db.subs/node-expanded? indexed-path])
+        expand-all? (rf/subscribe [::app-db.subs/expand-all?])]
     (fn [jsonml indexed-path]
       [:span
        {:class (jsonml-style)}
        [:span {:class    (toggle-style :bright)
                :on-click #(rf/dispatch [::app-db.events/toggle-expansion indexed-path])}
         [:button
-         (if @expanded?
+         (if (or @expand-all? @expanded?)
            [material/arrow-drop-down]
            [material/arrow-right])]]
-       (if (and @expanded? (has-body (get-object jsonml) (get-config jsonml)))
+       (if (and (or @expand-all? @expanded?) (has-body (get-object jsonml) (get-config jsonml)))
          (jsonml->hiccup-with-path-annotations
            (body
              (get-object jsonml)

--- a/src/day8/re_frame_10x/components/cljs_devtools.cljs
+++ b/src/day8/re_frame_10x/components/cljs_devtools.cljs
@@ -307,7 +307,8 @@
         [:span
          {:class (jsonml-style)}
          [:span {:class    (toggle-style :bright)
-                 :on-click #(rf/dispatch [::app-db.events/toggle-expansion indexed-path])}
+                 :on-click #(do (rf/dispatch [::app-db.events/toggle-expansion indexed-path])
+                                (rf/dispatch [::app-db.events/set-expand-all? path-id nil]))}
           [:button
            (if show-body?
              [material/arrow-drop-down]

--- a/src/day8/re_frame_10x/panels/app_db/events.cljs
+++ b/src/day8/re_frame_10x/panels/app_db/events.cljs
@@ -126,5 +126,5 @@
 (rf/reg-event-db
   ::set-expand-all?
   [(rf/path [:app-db :expand-all?]) rf/trim-v]
-  (fn [_ [expand-all?]]
-    expand-all?))
+  (fn [db [path-id expand?]]
+    (assoc db path-id expand?)))

--- a/src/day8/re_frame_10x/panels/app_db/events.cljs
+++ b/src/day8/re_frame_10x/panels/app_db/events.cljs
@@ -122,3 +122,9 @@
   (fn [paths [path-id sort]]
     (-> paths
         (assoc-in [path-id :sort?] sort))))
+
+(rf/reg-event-db
+  ::set-expand-all?
+  [(rf/path [:app-db :expand-all?]) rf/trim-v]
+  (fn [_ [expand-all?]]
+    expand-all?))

--- a/src/day8/re_frame_10x/panels/app_db/subs.cljs
+++ b/src/day8/re_frame_10x/panels/app_db/subs.cljs
@@ -57,5 +57,5 @@
 (rf/reg-sub
   ::expand-all?
   :<- [::root]
-  (fn [{:keys [expand-all?]} _]
-    expand-all?))
+  (fn [{:keys [expand-all?]} [_ path-id]]
+    (get expand-all? path-id)))

--- a/src/day8/re_frame_10x/panels/app_db/subs.cljs
+++ b/src/day8/re_frame_10x/panels/app_db/subs.cljs
@@ -54,3 +54,8 @@
   (fn [{:keys [reagent-id]} _]
     reagent-id))
 
+(rf/reg-sub
+  ::expand-all?
+  :<- [::root]
+  (fn [{:keys [expand-all?]} _]
+    expand-all?))

--- a/src/day8/re_frame_10x/panels/app_db/views.cljs
+++ b/src/day8/re_frame_10x/panels/app_db/views.cljs
@@ -73,7 +73,7 @@
 
 (defn pod-header [{:keys [id path-str open? diff? sort?]} data]
   (let [ambiance    @(rf/subscribe [::settings.subs/ambiance])
-        expand-all? @(rf/subscribe [::app-db.subs/expand-all?])]
+        expand-all? @(rf/subscribe [::app-db.subs/expand-all? id])]
     [rc/h-box
      :class    (styles/section-header ambiance)
      :align    :center
@@ -135,10 +135,11 @@
        :width    "49px"
        :justify  :center
        :align    :center
-       :attr     {:on-click (handler-fn (rf/dispatch [::app-db.events/set-expand-all? (not expand-all?)]))}
+       :attr     {:on-click (handler-fn (rf/dispatch [::app-db.events/set-expand-all? id (not expand-all?)]))}
        :children
        [[buttons/icon {:icon     [(if expand-all? material/unfold-less material/unfold-more)]
-                       :on-click #(rf/dispatch [::app-db.events/set-expand-all? (not expand-all?)])}]]]
+                       :title    (if expand-all? "Collapse app-db" "Expand app-db")
+                       :on-click #(rf/dispatch [::app-db.events/set-expand-all? id (not expand-all?)])}]]]
       [pod-header-section
        :width    styles/gs-50s
        :justify  :center
@@ -181,8 +182,9 @@
            [[cljs-devtools/simple-render-with-path-annotations
              data
              ["app-db-path" path]
-             {:update-path-fn [::app-db.events/update-path id]
-              :sort? sort?}]]])
+             {:path-id        id
+              :update-path-fn [::app-db.events/update-path id]
+              :sort?          sort?}]]])
         (when render-diff?
           (let [app-db-before (rf/subscribe [::app-db.subs/current-epoch-app-db-before])
                 [diff-before diff-after _] (when render-diff?
@@ -244,37 +246,37 @@
 
 (defn pod-header-column-titles
   []
-  (let [expand-all? @(rf/subscribe [::app-db.subs/expand-all?])] [rc/h-box
-    :height styles/gs-19s
-    :align  :center
-    :children
-    [[rc/gap-f :size styles/gs-31s]
-     [rc/box
-      :size   "1"
-      :height "31px"
-      :child  ""]
-     [rc/box
-      :width   styles/gs-50s                                  ;;  50px + 1 border
-      :justify :center
-      :child   [rc/label :style {:font-size "9px"} :label "DIFFS"]]
-     [rc/box
-      :width   styles/gs-50s                                  ;;  50px + 1 border
-      :justify :center
-      :child   [rc/label :style {:font-size "9px"} :label "SORT"]]
-     [rc/box
-      :width   styles/gs-50s                                  ;;  50px + 1 border
-      :justify :center
-      :child   [rc/label :style {:font-size "9px"} :label (if expand-all? "COLLAPSE" "EXPAND")]]
-     [rc/box
-      :width   styles/gs-50s                                  ;;  50px + 1 border
-      :justify :center
-      :child   [rc/label :style {:font-size "9px"} :label "DELETE"]]
-     [rc/box
-      :width   styles/gs-31s                                  ;;  31px + 1 border
-      :justify :center
-      :child   [rc/label :style {:font-size "9px"} :label ""]]
-     [rc/gap-f :size styles/gs-2s]
-     #_[rc/gap-f :size "6px"]]]))                     ;; Add extra space to look better when there is/aren't scrollbars
+  [rc/h-box
+   :height styles/gs-19s
+   :align  :center
+   :children
+   [[rc/gap-f :size styles/gs-31s]
+    [rc/box
+     :size   "1"
+     :height "31px"
+     :child  ""]
+    [rc/box
+     :width   styles/gs-50s                                  ;;  50px + 1 border
+     :justify :center
+     :child   [rc/label :style {:font-size "9px"} :label "DIFFS"]]
+    [rc/box
+     :width   styles/gs-50s                                  ;;  50px + 1 border
+     :justify :center
+     :child   [rc/label :style {:font-size "9px"} :label "SORT"]]
+    [rc/box
+     :width   styles/gs-50s                                  ;;  50px + 1 border
+     :justify :center
+     :child   [rc/label :style {:font-size "9px"} :label "EXPAND"]]
+    [rc/box
+     :width   styles/gs-50s                                  ;;  50px + 1 border
+     :justify :center
+     :child   [rc/label :style {:font-size "9px"} :label "DELETE"]]
+    [rc/box
+     :width   styles/gs-31s                                  ;;  31px + 1 border
+     :justify :center
+     :child   [rc/label :style {:font-size "9px"} :label ""]]
+    [rc/gap-f :size styles/gs-2s]
+    #_[rc/gap-f :size "6px"]]])                     ;; Add extra space to look better when there is/aren't scrollbars
 
 (defn pod-section []
   (let [pods @(rf/subscribe [::app-db.subs/paths])]

--- a/src/day8/re_frame_10x/panels/app_db/views.cljs
+++ b/src/day8/re_frame_10x/panels/app_db/views.cljs
@@ -72,7 +72,8 @@
      :children   children]))
 
 (defn pod-header [{:keys [id path-str open? diff? sort?]} data]
-  (let [ambiance @(rf/subscribe [::settings.subs/ambiance])]
+  (let [ambiance    @(rf/subscribe [::settings.subs/ambiance])
+        expand-all? @(rf/subscribe [::app-db.subs/expand-all?])]
     [rc/h-box
      :class    (styles/section-header ambiance)
      :align    :center
@@ -130,6 +131,14 @@
          :model sort?
          :label ""
          :on-change #(rf/dispatch [::app-db.events/set-sort-form? id (not sort?)])]]]
+      [pod-header-section
+       :width    "49px"
+       :justify  :center
+       :align    :center
+       :attr     {:on-click (handler-fn (rf/dispatch [::app-db.events/set-expand-all? (not expand-all?)]))}
+       :children
+       [[buttons/icon {:icon     [(if expand-all? material/unfold-less material/unfold-more)]
+                       :on-click #(rf/dispatch [::app-db.events/set-expand-all? (not expand-all?)])}]]]
       [pod-header-section
        :width    styles/gs-50s
        :justify  :center
@@ -235,33 +244,37 @@
 
 (defn pod-header-column-titles
   []
-  [rc/h-box
-   :height   styles/gs-19s
-   :align    :center
-   :children
-   [[rc/gap-f :size styles/gs-31s]
-    [rc/box
-     :size  "1"
-     :height "31px"
-     :child ""]
-    [rc/box
-     :width   styles/gs-50s                                ;;  50px + 1 border
-     :justify :center
-     :child   [rc/label :style {:font-size "9px"} :label "DIFFS"]]
-    [rc/box
-     :width   styles/gs-50s                                ;;  50px + 1 border
-     :justify :center
-     :child   [rc/label :style {:font-size "9px"} :label "SORT"]]
-    [rc/box
-     :width   styles/gs-50s                                ;;  50px + 1 border
-     :justify :center
-     :child   [rc/label :style {:font-size "9px"} :label "DELETE"]]
-    [rc/box
-     :width   styles/gs-31s                                ;;  31px + 1 border
-     :justify :center
-     :child   [rc/label :style {:font-size "9px"} :label ""]]
-    [rc/gap-f :size styles/gs-2s]
-    #_[rc/gap-f :size "6px"]]])                     ;; Add extra space to look better when there is/aren't scrollbars
+  (let [expand-all? @(rf/subscribe [::app-db.subs/expand-all?])] [rc/h-box
+    :height styles/gs-19s
+    :align  :center
+    :children
+    [[rc/gap-f :size styles/gs-31s]
+     [rc/box
+      :size   "1"
+      :height "31px"
+      :child  ""]
+     [rc/box
+      :width   styles/gs-50s                                  ;;  50px + 1 border
+      :justify :center
+      :child   [rc/label :style {:font-size "9px"} :label "DIFFS"]]
+     [rc/box
+      :width   styles/gs-50s                                  ;;  50px + 1 border
+      :justify :center
+      :child   [rc/label :style {:font-size "9px"} :label "SORT"]]
+     [rc/box
+      :width   styles/gs-50s                                  ;;  50px + 1 border
+      :justify :center
+      :child   [rc/label :style {:font-size "9px"} :label (if expand-all? "COLLAPSE" "EXPAND")]]
+     [rc/box
+      :width   styles/gs-50s                                  ;;  50px + 1 border
+      :justify :center
+      :child   [rc/label :style {:font-size "9px"} :label "DELETE"]]
+     [rc/box
+      :width   styles/gs-31s                                  ;;  31px + 1 border
+      :justify :center
+      :child   [rc/label :style {:font-size "9px"} :label ""]]
+     [rc/gap-f :size styles/gs-2s]
+     #_[rc/gap-f :size "6px"]]]))                     ;; Add extra space to look better when there is/aren't scrollbars
 
 (defn pod-section []
   (let [pods @(rf/subscribe [::app-db.subs/paths])]


### PR DESCRIPTION
This PR fixes #82 
Adds a button beside sort and delete app-db that can be used to expand or collapse the entire app db.

![mouse over expand](https://user-images.githubusercontent.com/38689046/148394348-223a8da9-9d30-47db-99d7-0242b9a0380c.jpg)

