### PR TITLE
Improve filtering in traces tab

### DIFF
--- a/src/day8/re_frame_10x/panels/traces/events.cljs
+++ b/src/day8/re_frame_10x/panels/traces/events.cljs
@@ -50,7 +50,7 @@
                       filters)]
         (conj filters
               {:id    (random-uuid)
-               :query (if (= type :contains)
+               :query (if (or (= type :contains) (= type :contains-not))
                         (string/lower-case query)
                         (js/parseFloat query))
                :type  type})))))

--- a/src/day8/re_frame_10x/panels/traces/subs.cljs
+++ b/src/day8/re_frame_10x/panels/traces/subs.cljs
@@ -117,10 +117,16 @@
     (filter (fn [trace] (when (contains? categories (:op-type trace)) trace)) traces)))
 
 (defn query->fn [query]
-  (if (= :contains (:type query))
+  (cond
+    (= :contains (:type query))
     (fn [trace]
       (string/includes? (string/lower-case (str (:operation trace) " " (:op-type trace)))
                         (:query query)))
+    (= :contains-not (:type query))
+    (fn [trace]
+      (not (string/includes? (string/lower-case (str (:operation trace) " " (:op-type trace)))
+                             (:query query))))
+    :else
     (fn [trace]
       (< (:query query) (:duration trace)))))
 

--- a/src/day8/re_frame_10x/panels/traces/views.cljs
+++ b/src/day8/re_frame_10x/panels/traces/views.cljs
@@ -136,6 +136,7 @@
                 :on-change #(rf/dispatch [::traces.events/set-draft-query-type
                                           (keyword (.. % -target -value))])}
        [:option {:value "contains"} "contains"]
+       [:option {:value "contains-not"} "doesn't contain"]
        [:option {:value "slower-than"} "slower than"]]
       [inputs/search
        {:on-save     #(rf/dispatch [::traces.events/save-draft-query])


### PR DESCRIPTION
Fix #124 
Adds a `doesn't contain` filter in traces tab
Makes the filters act as OR not AND.


![preview](https://user-images.githubusercontent.com/38689046/148403346-b1ab69bd-f992-4f5c-b037-ed3eedd4f8c1.png)

