### PR TITLE
Fix menu positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This change
 
 ## Unreleased
 
+#### Changed
+- Upgrade devtools to version 1.0.6
+
 #### Fixed
 - Fix path annotations menu positioning. See #348.
 - Add option to open new inspectors by default. See #347 and #348.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. This change
 ## Unreleased
 
 #### Fixed
+- Fix path annotations menu positioning
+
+## 1.2.4 (2022-4-6)
+
+#### Fixed
 - Fix path inspector `get-in` in lazy sequences.
 - Change expand app-db button tooltip. See #347.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file. This change
 ## Unreleased
 
 #### Fixed
-- Fix path annotations menu positioning
+- Fix path annotations menu positioning. See #348.
+- Add option to open new inspectors by default. See #347 and #348.
 
 ## 1.2.4 (2022-4-6)
 

--- a/examples/todomvc/shadow-cljs.edn
+++ b/examples/todomvc/shadow-cljs.edn
@@ -7,7 +7,7 @@
   [zprint                               "1.0.1"]
   [superstructor/re-highlight           "1.1.0"]
   [secretary                            "1.2.3"]
-  [binaryage/devtools                   "1.0.4"]
+  [binaryage/devtools                   "1.0.6"]
   [metosin/malli                        "0.5.1"]]
 
  :source-paths ["src" "../../src" "../../gen-src"]

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
 
   :dependencies [[org.clojure/clojure                  "1.10.3"   :scope "provided"]
                  [org.clojure/clojurescript            "1.10.879" :scope "provided"]
-                 [binaryage/devtools                   "1.0.5"]
+                 [binaryage/devtools                   "1.0.6"]
                  [com.yahoo.platform.yui/yuicompressor "2.4.8"
                   :exclusions [rhino/js]]
                  [zprint                               "1.0.1"]

--- a/src/day8/re_frame_10x/events.cljs
+++ b/src/day8/re_frame_10x/events.cljs
@@ -37,11 +37,13 @@
    (rf/inject-cofx ::local-storage/load {:key "categories" :or #{:event :sub/run :sub/create :sub/dispose}})
    (rf/inject-cofx ::local-storage/load {:key "data-path-annotations?" :or false})
    (rf/inject-cofx ::local-storage/load {:key "show-event-history" :or true})
+   (rf/inject-cofx ::local-storage/load {:key "open-new-inspectors?" :or true})
    rf/unwrap]
   (fn [{:keys [panel-width-ratio show-panel selected-tab filter-items app-db-json-ml-expansions
                external-window? external-window-dimensions show-epoch-traces? using-trace?
                ignored-events low-level-trace filtered-view-trace retained-epochs app-db-paths
-               app-db-follow-events? ambiance syntax-color-scheme categories data-path-annotations? show-event-history]}
+               app-db-follow-events? ambiance syntax-color-scheme categories data-path-annotations?
+               show-event-history open-new-inspectors?]}
        {:keys [debug?]}]
     {:fx [(when using-trace?
             [:dispatch [::settings.events/enable-tracing]])
@@ -68,7 +70,8 @@
           [:dispatch [::app-db.events/set-json-ml-paths app-db-json-ml-expansions]]
           [:dispatch [:global/add-unload-hook]]
           [:dispatch [::app-db.events/reagent-id]]
-          [:dispatch [::settings.events/show-event-history? show-event-history]]]}))
+          [:dispatch [::settings.events/show-event-history? show-event-history]]
+          [:dispatch [::settings.events/open-new-inspectors? open-new-inspectors?]]]}))
 
 ;; Global
 

--- a/src/day8/re_frame_10x/panels/app_db/events.cljs
+++ b/src/day8/re_frame_10x/panels/app_db/events.cljs
@@ -25,11 +25,11 @@
 (rf/reg-event-db
   ::create-path
   paths-interceptors
-  (fn [paths _]
+  (fn [paths [open-new-inspectors?]]
     (assoc paths
       (js/Date.now)
       {:diff?       false
-       :open?       false
+       :open?       open-new-inspectors?
        :path        nil
        :path-str    ""
        :valid-path? true})))
@@ -37,12 +37,12 @@
 (rf/reg-event-fx
   ::create-path-and-skip-to
   paths-interceptors
-  (fn [{:keys [db]} [skip-to-path]]
+  (fn [{:keys [db]} [skip-to-path open-new-inspectors?]]
     (let [path-id (js/Date.now)]
       {:db       (assoc db
                    path-id
                    {:diff?       false
-                    :open?       false
+                    :open?       open-new-inspectors?
                     :path        nil
                     :path-str    ""
                     :valid-path? true})

--- a/src/day8/re_frame_10x/panels/app_db/views.cljs
+++ b/src/day8/re_frame_10x/panels/app_db/views.cljs
@@ -168,7 +168,7 @@
        :attr     {:on-click (handler-fn (rf/dispatch [::app-db.events/set-expand-all? id (not expand-all?)]))}
        :children
        [[buttons/icon {:icon     [(if expand-all? material/unfold-less material/unfold-more)]
-                       :title    (if expand-all? "Close all nodes in this inspector" "Expand all nodes in this inspector")
+                       :title    (str (if expand-all? "Close" "Expand") " all nodes in this inspector")
                        :on-click #(rf/dispatch [::app-db.events/set-expand-all? id (not expand-all?)])}]]]
       [pod-header-section
        :width    styles/gs-50s
@@ -187,6 +187,7 @@
          :style {:margin "auto"}
          :child
          [buttons/icon {:icon [material/print]
+                        :title    "Dump inspector data into DevTools"
                         :on-click #(js/console.log data)}]]]]]]))
 
 (def diff-url "https://github.com/day8/re-frame-10x/blob/master/docs/HyperlinkedInformation/Diffs.md")

--- a/src/day8/re_frame_10x/panels/app_db/views.cljs
+++ b/src/day8/re_frame_10x/panels/app_db/views.cljs
@@ -27,7 +27,8 @@
 
 (defn path-inspector-button
   []
-  (let [ambiance @(rf/subscribe [::settings.subs/ambiance])]
+  (let [ambiance             @(rf/subscribe [::settings.subs/ambiance])
+        open-new-inspectors? @(rf/subscribe [::settings.subs/open-new-inspectors?])]
     [rc/button
      :class    (styles/button ambiance)
      :label    [rc/h-box
@@ -35,7 +36,7 @@
                 :children [[material/add
                             {:size styles/gs-19s}]
                            "path inspector"]]
-     :on-click #(rf/dispatch [::app-db.events/create-path])]))
+     :on-click #(rf/dispatch [::app-db.events/create-path open-new-inspectors?])]))
 
 (defn panel-header []
   [rc/h-box

--- a/src/day8/re_frame_10x/panels/settings/events.cljs
+++ b/src/day8/re_frame_10x/panels/settings/events.cljs
@@ -218,3 +218,9 @@
   [(rf/path [:settings :show-event-history?]) rf/trim-v (local-storage/save "show-event-history")]
   (fn [_ [show-event-history?]]
     show-event-history?))
+
+(rf/reg-event-db
+  ::open-new-inspectors?
+  [(rf/path [:settings :open-new-inspectors?]) rf/trim-v (local-storage/save "open-new-inspectors?")]
+  (fn [_ [open-new-inspectors?]]
+    open-new-inspectors?))

--- a/src/day8/re_frame_10x/panels/settings/subs.cljs
+++ b/src/day8/re_frame_10x/panels/settings/subs.cljs
@@ -117,3 +117,9 @@
   :<- [::root]
   (fn [{:keys [show-event-history?]} _]
     show-event-history?))
+
+(rf/reg-sub
+  ::open-new-inspectors?
+  :<- [::root]
+  (fn [{:keys [open-new-inspectors?]} _]
+    open-new-inspectors?))

--- a/src/day8/re_frame_10x/panels/settings/views.cljs
+++ b/src/day8/re_frame_10x/panels/settings/views.cljs
@@ -184,6 +184,16 @@
                  [[:p "Most of the time, low level trace is noisy and you want it filtered out."]]
                  settings-box-131])
 
+              [rc/line]
+              (let [open-inspectors? (rf/subscribe [::settings.subs/open-new-inspectors?])]
+                [settings-box
+                 [[rc/checkbox
+                   :model open-inspectors?
+                   :label "open new inspectors by default"
+                   :on-change #(rf/dispatch [::settings.events/open-new-inspectors? %])]]
+                 [[:p "Should all new inspectors in the app-db tab be opened by default?"]]
+                 settings-box-81])
+
               #_[rc/line] ;; [IJ] TODO: :dark ambiance theme is unfinished, so disabled for now.
               #_(let [ambiance @(rf/subscribe [::settings.subs/ambiance])]
                   [settings-box


### PR DESCRIPTION
Fixes #348 and #347

Commits in this PR include:

1. Fix menu positioning.
2. Update the Changelog.
3. Add print inspector button tooltip.
4. Add option to open new inspectors by default.
5. Upgrade Devtools to 1.0.6