### PR TITLE
Fix expand arrow toggling in app db tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## Unreleased
+
+#### Fixed
+- Fix top most level expand arrow toggling in app-db tab.
+
 ## 1.2.6 (2022-4-13)
 
 #### Changed

--- a/src/day8/re_frame_10x/components/cljs_devtools.cljs
+++ b/src/day8/re_frame_10x/components/cljs_devtools.cljs
@@ -293,14 +293,13 @@
              (get-config jsonml))
            (conj path :header)))])))
 
-(defn data-structure-with-path-annotations [_ indexed-path _ {:keys [path-id]}]
-  (let [expanded?     (rf/subscribe [::app-db.subs/node-expanded? indexed-path])
-        expand-all?   (rf/subscribe [::app-db.subs/expand-all? path-id]) ;; expand-all? default is nil,
+(defn data-structure-with-path-annotations [_ _ _ {:keys [path-id]}]
+  (let [expand-all?   (rf/subscribe [::app-db.subs/expand-all? path-id]) ;; default is nil, false means that we have collapsed the app-db
+        ;; true means we have expanded the whole db
         render-paths? (rf/subscribe [::app-db.subs/data-path-annotations?])]
-    ;; false means that we have collapsed the app-db
-    ;; true means we have expanded the whole db
     (fn [jsonml indexed-path devtools-path opts]
-      (let [show-body? (and (has-body (get-object jsonml) (get-config jsonml))
+      (let [expanded?  (rf/subscribe [::app-db.subs/node-expanded? indexed-path])
+            show-body? (and (has-body (get-object jsonml) (get-config jsonml))
                             (cond
                               @expand-all? true
                               (and @expanded? (not= @expand-all? false)) true))]


### PR DESCRIPTION
Fixes the issue where the top-most level arrow fails to close to expand db
See #347 