### PR TITLE
fix: cljs.core/abs replacement warning

### DIFF
--- a/gen-src/day8/re_frame_10x/inlined_deps/garden/v1v3v10/garden/color.cljc
+++ b/gen-src/day8/re_frame_10x/inlined_deps/garden/v1v3v10/garden/color.cljc
@@ -1,6 +1,6 @@
 (ns ^{:mranderson/inlined true} day8.re-frame-10x.inlined-deps.garden.v1v3v10.garden.color
   "Utilities for color creation, conversion, and manipulation."
-  (:refer-clojure :exclude [complement])
+  (:refer-clojure :exclude [complement abs])
   #?(:cljs
      (:require-macros
       [day8.re-frame-10x.inlined-deps.garden.v1v3v10.garden.color :refer [defcolor-operation]]))


### PR DESCRIPTION
@superstructor As you mentioned in #369, I changed the strategy to solve the abs replacement warning.

This commit fixes #363 