### PR TITLE
fix(zprint): update version to fix replacement warning

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [binaryage/devtools                   "1.0.6"]
                  [com.yahoo.platform.yui/yuicompressor "2.4.8"
                   :exclusions [rhino/js]]
-                 [zprint                               "1.0.1"]
+                 [zprint                               "1.2.1"]
                  [superstructor/re-highlight           "2.0.1"]
                  ;; re-highlight only has a transitive dependency on highlight.js for
                  ;; shadow-cljs builds, so we need to declare a dependency on cljsjs/highlight


### PR DESCRIPTION
According to https://github.com/kkinnear/zprint/issues/215 this commit fixes abs replacement warning by updating the zprint version