### PR TITLE
Bumping zprint dep version.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [binaryage/devtools                   "1.0.6"]
                  [com.yahoo.platform.yui/yuicompressor "2.4.8"
                   :exclusions [rhino/js]]
-                 [zprint                               "1.2.1"]
+                 [zprint                               "1.2.5"]
                  [superstructor/re-highlight           "2.0.2"]
                  ;; re-highlight only has a transitive dependency on highlight.js for
                  ;; shadow-cljs builds, so we need to declare a dependency on cljsjs/highlight


### PR DESCRIPTION
Using re-frame-10x at 'latest' in our project showed a compilation warning.

`zprint/core.cljc` warns on use of deprecated `rewrite-clj.zip/edn* fn`

See https://github.com/kkinnear/zprint/blob/main/CHANGELOG.md#125---2023-01-24
> Upgraded to newer rewrite-clj, and changed edn* to of-node* to remove deprecation warnings. Issue #247.