### PR TITLE
Stretch the app-db path input field on firefox

### DIFF
--- a/src/day8/re_frame_10x/styles.cljs
+++ b/src/day8/re_frame_10x/styles.cljs
@@ -483,7 +483,7 @@
   [ambiance]
   {:background-color (background-color-1 ambiance)
    :height           (px 25)
-   :width            "-webkit-fill-available" ;; This took a bit of finding!
+   :width            #{"-webkit-fill-available" "-moz-available;"}
    :padding          [[0 gs-7]]
    :border           :none}
   [:&:focus


### PR DESCRIPTION
This hash-set is an undocumented feature of garden: https://github.com/noprompt/garden/issues/6

https://github.com/day8/re-frame-10x/issues/377
https://caniuse.com/mdn-css_properties_width_stretch