### PR TITLE
Fix ignored-events goog define

### DIFF
--- a/src/day8/re_frame_10x.cljs
+++ b/src/day8/re_frame_10x.cljs
@@ -159,11 +159,12 @@
 (def project-config
   (let [read      reader.edn/read-string-maybe
         keep-vals (remove (comp nil? second))
+        ignore    #(do {:event-id % :event-str (str %)})
         view      #(do {:ns % :ns-str (str %)})
         alias     (fn [[k v]] {:ns-full (str k) :ns-alias (str v)})]
     (->> {:debug?                 debug?
           :retained-epochs        history-size
-          :ignored-events         (some-> ignored-events read sortable-uuid-map)
+          :ignored-events         (some->> ignored-events read (map ignore) sortable-uuid-map)
           :filtered-view-trace    (some->> hidden-namespaces read (map view) sortable-uuid-map)
           :app-db-follows-events? time-travel?
           :low-level-trace        (some-> ignored-libs read (pred-map #{:re-frame :reagent}))


### PR DESCRIPTION
https://github.com/day8/re-frame-10x/issues/414

Previous goog define had to look something like:
```
day8.re-frame-10x.ignored-events
"{{:event-id :shared/loading?} {:event-str \":shared/loading?\"}
 {:event-id :state/restart-query} {:event-str \":state/restart-query\"}}"
```

This change brings it in line with view and alias.